### PR TITLE
lineage: Don't error out when screen size isn't set

### DIFF
--- a/bootanimation/Android.mk
+++ b/bootanimation/Android.mk
@@ -15,6 +15,15 @@
 # limitations under the License.
 #
 
+ifeq ($(TARGET_SCREEN_WIDTH),)
+    $(warning TARGET_SCREEN_WIDTH is not set, using default value: 1080)
+    TARGET_SCREEN_WIDTH := 1080
+endif
+ifeq ($(TARGET_SCREEN_HEIGHT),)
+    $(warning TARGET_SCREEN_HEIGHT is not set, using default value: 1920)
+    TARGET_SCREEN_HEIGHT := 1920
+endif
+
 define build-bootanimation
     sh vendor/lineage/bootanimation/generate-bootanimation.sh \
     $(TARGET_SCREEN_WIDTH) \
@@ -39,13 +48,6 @@ ifeq ($(TARGET_BOOTANIMATION),)
         $(info **********************************************)
         $(error stop)
     endif
-endif
-
-ifeq ($(TARGET_SCREEN_WIDTH),)
-    $(error TARGET_SCREEN_WIDTH must be set)
-endif
-ifeq ($(TARGET_SCREEN_HEIGHT),)
-    $(error TARGET_SCREEN_HEIGHT must be set)
 endif
 
 include $(CLEAR_VARS)


### PR DESCRIPTION
* Generic AOSP devices don't set it and we don't really
  want to fork them just to set the bootanimation size.

Change-Id: I684454ae07348ee29c832f86f56bcfbd4f627b4d